### PR TITLE
Add skillshub formula

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ build-iPhoneSimulator/
 # .rubocop-https?--*
 
 # End of https://www.toptal.com/developers/gitignore/api/homebrew,ruby,git
+
+**/skills

--- a/Formula/skillshub.rb
+++ b/Formula/skillshub.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Formula for installing Skillshub - a package manager for AI coding agent skills.
+# Builds from source using Rust and Cargo.
+class Skillshub < Formula
+  desc "Unified package manager for AI coding agent skills"
+  homepage "https://github.com/EYH0602/skillshub"
+  url "https://github.com/EYH0602/skillshub/archive/refs/tags/0.1.10.tar.gz"
+  sha256 "4e8b28de47ce8699ca4cc7461d9a911cfa0208d43520f7df95fc8ba0cede1960"
+  license "MIT"
+
+  depends_on "rust" => :build
+  depends_on "pkg-config" => :build
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+  end
+
+  def test
+    system "#{bin}/skillshub", "list"
+  end
+end

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "skills": {
+    "homebrew-cask-authoring": {
+      "source": "connorads/dotfiles",
+      "sourceType": "github",
+      "computedHash": "12342308d5863be4e48703172ae88bfca680c6ffb1ff227017e9a4d59b6d0760"
+    },
+    "homebrew-formula-maintenance": {
+      "source": "bobmatnyc/claude-mpm-skills",
+      "sourceType": "github",
+      "computedHash": "eb741693f5754655d6b1ffdd95708871f62bcb4f459738c474b482fdb878ad08"
+    }
+  }
+}


### PR DESCRIPTION
Add Homebrew formula for skillshub - a unified package manager for AI coding agent skills.

**Changes:**
- New formula in Formula/skillshub.rb for skillshub v0.1.10
- Builds from source using Rust and Cargo
- Includes proper licensing and dependencies

**Installation:**
```bash
brew tap abuxton/tap
brew install abuxton/tap/skillshub
```